### PR TITLE
セキュリティの認証処理を実装する

### DIFF
--- a/src/main/java/oit/is/z2421/kaizi/janken/security/Sample3AuthConfiguration.java
+++ b/src/main/java/oit/is/z2421/kaizi/janken/security/Sample3AuthConfiguration.java
@@ -1,0 +1,66 @@
+package oit.is.z2421.kaizi.janken.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class Sample3AuthConfiguration {
+  /**
+   * 認可処理に関する設定（認証されたユーザがどこにアクセスできるか）
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.formLogin(login -> login
+        .permitAll())
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/janken/**"))
+            .authenticated() // /janken/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**"))
+            .permitAll())// 上記以外は全員アクセス可能
+        .csrf(csrf -> csrf
+            .ignoringRequestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/*")))
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions
+                .sameOrigin()));
+    return http.build();
+  }
+
+  /**
+   * 認証処理に関する設定（誰がどのようなロールでログインできるか）
+   *
+   * @return
+   */
+  @Bean
+  public InMemoryUserDetailsManager userDetailsService() {
+
+    // ユーザ名，パスワード，ロールを指定してbuildする
+    // このときパスワードはBCryptでハッシュ化されているため，{bcrypt}とつける
+    // ハッシュ化せずに平文でパスワードを指定する場合は{noop}をつける
+    // user1/p@ss,user2/p@ss,admin/p@ss
+    UserDetails user1 = User.withUsername("user1")
+        .password("{bcrypt}$2y$05$AzNAU89Cf2h5ghJg2gKGxuch0iSkdRyJ1RlPxqzWlrLVt00jd4UTK").roles("USER").build();
+    UserDetails user2 = User.withUsername("user2")
+        .password("{bcrypt}$2y$05$QTc2gAEod8WH4EKdCCihve.D.Z0o5w7XIIa4by8i9G1CsIln/Z6MO").roles("USER").build();
+    UserDetails admin = User.withUsername("admin")
+        .password("{bcrypt}$2y$10$ngxCDmuVK1TaGchiYQfJ1OAKkd64IH6skGsNw1sLabrTICOHPxC0e").roles("ADMIN").build();
+
+    // 生成したユーザをImMemoryUserDetailsManagerに渡す（いくつでも良い）
+    return new InMemoryUserDetailsManager(user1, user2, admin);
+  }
+
+}


### PR DESCRIPTION
・ユーザIDがuser1とuser2のユーザを2名分追加する．ロールはUSERとする．
　パスワードはどちらも必ずisdevとし，bcryptでハッシュ化したものを利用する
・以下の3つの認可に伴う処理をJankenAuthConfiguration.javaに実装する
　・SpringSecurityのフォームを利用する
　・/janken で始まるURLへのアクセス時に認証を必要とする
　・ログアウト時にはトップページ (http://localhost:8080/)に戻る